### PR TITLE
Typo Patch

### DIFF
--- a/src/main/resources/messages_da.properties
+++ b/src/main/resources/messages_da.properties
@@ -65,11 +65,11 @@ CMD_WHITELIST_IP_HOVER=&c&l/chatfilter whitelist add ip <ip/adresse>&r \n&7Tilf�
 
 CMD_WHITELIST_LIST=&c/chatfilter whitetlist list <word/ip>
 CMD_WHITELIST_LIST_HOVER=&c&l/chatfilter whitelist list (word/ip)&r \n&7Liste over alle hvidlistede ord/IP.
-CMD_WHITELIST_REMOVE_HOVER=&c&l/chat filter hvidliste fjerne (ord/ip)&r \n&7Fjerner valgte hvidlistede ord/IP.
-CMD_WHITELIST_REMOVE=&c/chat filter hvidliste fjerne <ord/ip>
-CMD_BLACKLIST_REMOVE=&c/chatlifter blacklist remove <ord/ip>
+CMD_WHITELIST_REMOVE_HOVER=&c&l/chatfilter hvidliste fjerne (ord/ip)&r \n&7Fjerner valgte hvidlistede ord/IP.
+CMD_WHITELIST_REMOVE=&c/chatfilter hvidliste fjerne <ord/ip>
+CMD_BLACKLIST_REMOVE=&c/chatfilter blacklist remove <ord/ip>
 CMD_BLACKLIST_REMOVE_HOVER=&c&l/chatfilter blacklist remove (ord/ip)&r \n&7Fjerner valgte sortlistede ord/IP.
-CMD_PAUSE=&c/chatlifter pause
+CMD_PAUSE=&c/chatfilter pause
 CMD_PAUSE_HOVER=&c&l/chatfilter pause&r \n&7Forhindre spillere i at bruge chat.\nKør kommando for at slå til/fra
 
 

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -64,10 +64,10 @@ CMD_WHITELIST_IP_HOVER=&c&l/chatfilter whitelist add ip <ip/address>&r \n&7Adds 
 CMD_WHITELIST_LIST=&c/chatfilter whitetlist list <word/ip>
 CMD_WHITELIST_LIST_HOVER=&c&l/chatfilter whitelist list (word/ip)&r \n&7List of all whitelisted words/IP.
 CMD_WHITELIST_REMOVE_HOVER=&c&l/chatfilter whitelist remove (word/ip)&r \n&7Removes chosen whitelisted words/IP.
-CMD_WHITELIST_REMOVE=&c/chatlifter whitelist remove <word/ip>
-CMD_BLACKLIST_REMOVE=&c/chatlifter blacklist remove <word/ip>
+CMD_WHITELIST_REMOVE=&c/chatfilter whitelist remove <word/ip>
+CMD_BLACKLIST_REMOVE=&c/chatfilter blacklist remove <word/ip>
 CMD_BLACKLIST_REMOVE_HOVER=&c&l/chatfilter blacklist remove (word/ip)&r \n&7Removes chosen blacklisted words/IP.
-CMD_PAUSE=&c/chatlifter pause
+CMD_PAUSE=&c/chatfilter pause
 CMD_PAUSE_HOVER=&c&l/chatfilter pause&r \n&7Prevent players from using chat.\nRun command to toggle on/off
 
 

--- a/src/main/resources/messages_es.properties
+++ b/src/main/resources/messages_es.properties
@@ -69,10 +69,10 @@ CMD_WHITELIST_IP_HOVER=&c&l/chatfilter whitelist add ip <direccion/ip>&r \n&7Agr
 CMD_WHITELIST_LIST=&c/chatfilter whitetlist list <word/ip>
 CMD_WHITELIST_LIST_HOVER=&c&l/chatfilter whitelist list (word/ip)&r \n&7Lista de todas las palabras/IP en la whitelist.
 CMD_WHITELIST_REMOVE_HOVER=&c&l/chatfilter whitelist remove (word/ip)&r \n&7Remueve la palabra/ip seleccionada de la whitelist
-CMD_WHITELIST_REMOVE=&c/chatlifter whitelist remove <word/ip>
-CMD_BLACKLIST_REMOVE=&c/chatlifter blacklist remove <word/ip>
+CMD_WHITELIST_REMOVE=&c/chatfilter whitelist remove <word/ip>
+CMD_BLACKLIST_REMOVE=&c/chatfilter blacklist remove <word/ip>
 CMD_BLACKLIST_REMOVE_HOVER=&c&l/chatfilter blacklist remove (word/ip)&r \n&7Remueve la palabra/Ip de la blacklist.
-CMD_PAUSE=&c/chatlifter pause
+CMD_PAUSE=&c/chatfilter pause
 CMD_PAUSE_HOVER=&c&l/chatfilter pause&r \n&7Previene a los jugadores de usar el Chat\nUsar el comando para pausar/despausar
  
  

--- a/src/main/resources/messages_pl.properties
+++ b/src/main/resources/messages_pl.properties
@@ -71,10 +71,10 @@ CMD_WHITELIST_IP_HOVER=&c&l/chatfilter whitelist add ip <ip/adres>&r \n&7Dodaje 
 CMD_WHITELIST_LIST=&c/chatfilter whitetlist list <word/ip>
 CMD_WHITELIST_LIST_HOVER=&c&l/chatfilter whitelist list (word/ip)&r \n&7Lista wszystkich slow/IP na bialej liscie.
 CMD_WHITELIST_REMOVE_HOVER=&c&l/chatfilter whitelist remove (word/ip)&r \n&7Usuwa wybrane slowa/IP z bialej listy.
-CMD_WHITELIST_REMOVE=&c/chatlifter whitelist remove <word/ip>
-CMD_BLACKLIST_REMOVE=&c/chatlifter blacklist remove <word/ip>
+CMD_WHITELIST_REMOVE=&c/chatfilter whitelist remove <word/ip>
+CMD_BLACKLIST_REMOVE=&c/chatfilter blacklist remove <word/ip>
 CMD_BLACKLIST_REMOVE_HOVER=&c&l/chatfilter blacklist remove (word/ip)&r \n&7Usuwa wybrane slowa/IP z czarnej listy.
-CMD_PAUSE=&c/chatlifter pause
+CMD_PAUSE=&c/chatfilter pause
 CMD_PAUSE_HOVER=&c&l/chatfilter pause&r \n&7Zapobiega graczom korzystanie z czatu .\nUzyj polecenia aby wylaczyc/wlaczyc uzytek.
 
 


### PR DESCRIPTION
Fixed typo in the languages files, where the command /chatlifter appeared on some rows, instead of /chatfilter